### PR TITLE
libtheora: reinstate version 1.1.1

### DIFF
--- a/recipes/libtheora/libtheora_1.1.1.oe
+++ b/recipes/libtheora/libtheora_1.1.1.oe
@@ -5,7 +5,7 @@ LICENSE = "BSD"
 
 inherit autotools pkgconfig
 
-SRC_URI = "http://downloads.xiph.org/releases/theora/libtheora-${PV}.tar.gz"
+SRC_URI = "http://downloads.xiph.org/releases/theora/libtheora-${PV}.tar.bz2"
 
 DEPENDS = "libogg"
 

--- a/recipes/libtheora/libtheora_1.1.1.oe.sig
+++ b/recipes/libtheora/libtheora_1.1.1.oe.sig
@@ -1,0 +1,1 @@
+8dcaa8e61cd86eb1244467c0b64b9ddac04ae262  libtheora-1.1.1.tar.bz2

--- a/recipes/libtheora/libtheora_1.2.0alpha1.oe.sig
+++ b/recipes/libtheora/libtheora_1.2.0alpha1.oe.sig
@@ -1,1 +1,0 @@
-f03e6b1648b7574a249ee19cd386ff3d5c9deb84  libtheora-1.2.0alpha1.tar.gz


### PR DESCRIPTION
This reverts commits

  b337619d libtheora: Remove version 1.1.1
  18a7b76d libtheora: Add version 1.20alpha1

libtheora 1.2.0alpha1 fails to compile for me using the standard
arm-926ejs-linux MACHINE_CPU, with errors such as

  armloop-gnu.S:533: Error: selected processor does not support ARM mode `vst1.16 {D2[1]},[r12],r1'

Apparently (http://www.theora.org/downloads/) there haven't been any
more releases towards 1.2 since the above commits were made, nor any
release in the 1.1.x branch. So let's reinstate the latest stable
version for now, to allow the buildbot's "oe bake world" to succeed with
the meta/multimedia layer enabled.