### PR TITLE
mp4v2: patch out help2man from doc Makefile

### DIFF
--- a/recipes/mp4v2/files/disable_help2man.patch
+++ b/recipes/mp4v2/files/disable_help2man.patch
@@ -1,0 +1,31 @@
+help2man generates a trivial man page for $command from the output of
+"$command --help". This obviously doesn't work when cross-compiling,
+but the build system unconditionally picks up help2man if it is
+available on the host, and there's no way to disable it with a
+configure flag.
+
+Upstream-status: inappropriate
+Source: OE-lite
+
+--- mp4v2-1.9.1/doc/GNUmakefile.mk.orig	2017-01-05 23:20:11.376734888 +0000
++++ mp4v2-1.9.1/doc/GNUmakefile.mk	2017-01-05 23:20:29.076803352 +0000
+@@ -59,13 +59,13 @@
+ M4.cmd   = $(M4) $(M4.flags) $(1) > $(2)
+ M4.deps  = $(BUILD/)project/project.m4
+ 
+-ifeq ($(FOUND_HELP2MAN),yes)
+-HELP2MAN       = help2man
+-HELP2MAN.flags = -m "$(PROJECT_name) Utilities" -N
+-HELP2MAN.cmd   = $(HELP2MAN) $(HELP2MAN.flags) ./$(1) -o $(2)
+-else
++#ifeq ($(FOUND_HELP2MAN),yes)
++#HELP2MAN       = help2man
++#HELP2MAN.flags = -m "$(PROJECT_name) Utilities" -N
++#HELP2MAN.cmd   = $(HELP2MAN) $(HELP2MAN.flags) ./$(1) -o $(2)
++#else
+ HELP2MAN.cmd = touch $(2)
+-endif
++#endif
+ 
+ MAKEINFO.flags      = -I$(DOC.in/)texi -I$(DOC.out/)texi
+ MAKEINFO.flags.html = --html --no-headers --no-split

--- a/recipes/mp4v2/mp4v2.inc
+++ b/recipes/mp4v2/mp4v2.inc
@@ -4,6 +4,7 @@ LICENSE = "MPL LGPL2"
 COMPATIBLE_HOST_ARCHS = "i.86-.*-.*linux- x86_64-.*-.*linux- powerpc-.*-.*linux- powerpc64-.*-.*linux- arm-.*-.*linux-"
 
 SRC_URI = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mp4v2/mp4v2-${PV}.tar.bz2"
+SRC_URI += "file://disable_help2man.patch"
 
 inherit c++ autotools auto-package-utils library
 


### PR DESCRIPTION
When the host has help2man installed, the build fails when it tries to
run "foo --help". This was the simplest way I could find to work around
that.